### PR TITLE
add release target and push additional docker image

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -137,3 +137,23 @@ jobs:
         with:
           path: ${{ env.SERVICE_NAME }}-${{ needs.versioning.outputs.version }}.tgz
           destination: ${{ secrets[steps.repository.outputs.helmRepo] }}/${{ env.SERVICE_NAME }}
+  
+  release:
+    runs-on: ubuntu-latest
+    name: package artifacts
+    needs: [versioning, package]
+    if: ${{ needs.versioning.outputs.isRelease == 'true' }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: push tag
+        uses: mathieudutour/github-tag-action@v5.4
+        with:
+          github_token: ${{ secrets.GH_BOT_TOKEN }}
+          custom_tag: ${{ needs.versioning.outputs.version }}
+          create_annotated_tag: true
+      
+      - name: Release
+        uses: softprops/action-gh-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,9 +65,8 @@ jobs:
       - name: Build Docker Image
         run: |
           make docker tag=latest
-          ## push pr tag
           docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/$SERVICE_NAME:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/$SERVICE_NAME:${{ steps.tag.outputs.pr_number }}
-          docker push !$
+          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/$SERVICE_NAME:${{ steps.tag.outputs.pr_number }}
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           make docker tag=latest
           ## push pr tag
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/{{ env.SERVICE_NAME }}:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/{{ env.SERVICE_NAME }}:${{ steps.tag.outputs.pr_number }}
+          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ steps.tag.outputs.pr_number }}
           docker push !$
 
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           make docker tag=latest
           ## push pr tag
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ steps.tag.outputs.pr_number }}
+          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/$SERVICE_NAME:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/$SERVICE_NAME:${{ steps.tag.outputs.pr_number }}
           docker push !$
 
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,21 +39,18 @@ jobs:
     
       - name: package helm
         run: |
-          echo HELM_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g') >> $GITHUB_ENV
-          helm dep up $HELM_DIRECTORY/$SERVICE_NAME
-          helm package $HELM_DIRECTORY/$SERVICE_NAME
+          make helm
       
       - name: Publish PR Chart
         run: |
-          mv $SERVICE_NAME-${{ env.HELM_VERSION }}.tgz $SERVICE_NAME-latest.tgz
           gsutil cp $SERVICE_NAME-*.tgz gs://${{ secrets.HELM_DEV_BUCKET }}/$SERVICE_NAME/
 
       - name: Check Copyright
         run: mvn license:check
 
-      - name: Build
+      - name: test
         run: |
-          mvn -B clean package -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip --file pom.xml
+          make verify
       
       - run: |
           gcloud auth configure-docker
@@ -67,7 +64,11 @@ jobs:
       
       - name: Build Docker Image
         run: |
-          make docker tag=${{ steps.tag.outputs.pr_number }}
+          make docker
+          ## push pr tag
+          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/{{ env.SERVICE_NAME }}:latest \ 
+            eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/{{ env.SERVICE_NAME }}:${{ steps.tag.outputs.pr_number }}
+          docker push !$
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,8 +66,7 @@ jobs:
         run: |
           make docker
           ## push pr tag
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/{{ env.SERVICE_NAME }}:latest \ 
-            eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/{{ env.SERVICE_NAME }}:${{ steps.tag.outputs.pr_number }}
+          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/{{ env.SERVICE_NAME }}:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/{{ env.SERVICE_NAME }}:${{ steps.tag.outputs.pr_number }}
           docker push !$
 
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ jobs:
       
       - name: Build Docker Image
         run: |
-          make docker
+          make docker tag=latest
           ## push pr tag
           docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/{{ env.SERVICE_NAME }}:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/{{ env.SERVICE_NAME }}:${{ steps.tag.outputs.pr_number }}
           docker push !$

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,7 @@ jobs:
     
       - name: package helm
         run: |
-          make helm
+          make helm version=latest
       
       - name: Publish PR Chart
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-name := securebanking-spring-config-server
+name := $(shell mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
 repo := sbat-gcr-develop
 tag  := $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <description>A Spring Cloud Config Server for the Secure Banking Accelerator Toolkit</description>
 
     <properties>
-        <tag>${project.version}</tag>
+        <tag>latest</tag>
         <gcrRepo>sbat-gcr-develop</gcrRepo>
     </properties>
 


### PR DESCRIPTION
Add a release target to the github actions on push to master.
A release will only occur when the pom version is semver compliant. This will prevent us from having to tag or release manually.

Default the pom tag property to latest. Now when ci calls `make docker`, the latest tag will be supplied and uploaded. Add an additional ci step for add and push the tag of the pr number to the dev repo.