### PR TITLE
ssh is optional

### DIFF
--- a/_infra/helm/securebanking-spring-config-server/templates/deployment.yaml
+++ b/_infra/helm/securebanking-spring-config-server/templates/deployment.yaml
@@ -53,11 +53,17 @@ spec:
           - name: SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT_LABEL
             value: {{ .Values.git.branch }}
           - name: SPRING_CLOUD_CONFIG_SERVER_GIT_URI
+            {{- if .Values.git.ssh.enabled }}
             value: git@github.com:{{ .Values.git.org }}/{{ .Values.git.repo }}.git
+            {{- else }}
+            value: https://github.com/{{ .Values.git.org }}/{{ .Values.git.repo }}.git
+            {{- end }}
+          {{ if .Values.git.ssh.enabled }}
           - name: GIT_CONFIG_SSH_KEY
             valueFrom:
               secretKeyRef: 
                 name: git-ssh-key
                 key: id_rsa
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/_infra/helm/securebanking-spring-config-server/templates/external-secret.yaml
+++ b/_infra/helm/securebanking-spring-config-server/templates/external-secret.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.git.ssh.enabled }}
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
@@ -6,8 +7,9 @@ metadata:
     "helm.sh/hook": pre-install
 spec:
   backendType: gcpSecretsManager
-  projectId: {{ .Values.git.storedSecretProject }}
+  projectId: {{ .Values.git.ssh.storedSecretProject }}
   data:
     - key: git-ssh-key
       name: id_rsa
       version: latest
+{{- end }}

--- a/_infra/helm/securebanking-spring-config-server/values.yaml
+++ b/_infra/helm/securebanking-spring-config-server/values.yaml
@@ -9,15 +9,17 @@ imagePullPolicy: Always
 # Deploy a different image to the intended release (useful for test and development)
 imageOverride:
   enabled: true
-  repo: eu.gcr.io/sbat-gcr-release/securebanking/spring-config-server
+  repo: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-spring-config-server
   tag: latest
 
 server:
   port: 8888
 
 git:
-  storedSecretProject: example-project
-  org: SecureBankingAcceleratorToolkit
+  ssh: 
+    enabled: false
+    storedSecretProject: example-project
+  org: SecureBankingAccessToolkit
   repo: securebanking-openbanking-spring-config
   branch: master
 


### PR DESCRIPTION
Make ssh optional in the helm chart. Right now our config is public and we do not need an ssh key for the spring config server to pull it. Default to git https.

Change the image override to use the develop gcr repo