### PR TITLE
use tag rather than repo

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          make docker repo=$(echo ${{ github.sha }} | cut -c1-7)
+          make docker tag=$(echo ${{ github.sha }} | cut -c1-7)
           docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ github.sha }} eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
           docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
       


### PR DESCRIPTION
The latest action failed to build due to an error setting the repo to the tag name.

Change `repo` to `tag`.
Repo will default to our private repository on merge to master.

issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/89