### PR TITLE
311: Create guaranteed QoS and set JAVA_OPTS

### DIFF
--- a/_infra/helm/securebanking-spring-config-server/templates/deployment.yaml
+++ b/_infra/helm/securebanking-spring-config-server/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ .Values.deployment.apiVersion }}
 kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
@@ -31,11 +31,11 @@ spec:
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
           ports:
             - name: http-server
-              containerPort: {{ .Values.server.port }}
+              containerPort: {{ .Values.deployment.server.port }}
           readinessProbe:
             httpGet:
               path: /actuator/health
-              port: {{ .Values.server.port }}
+              port: {{ .Values.deployment.server.port }}
             periodSeconds: 5
             failureThreshold: 3
             successThreshold: 1
@@ -43,8 +43,8 @@ spec:
           livenessProbe:
             httpGet:
               path: /actuator/health
-              port: {{ .Values.server.port }}
-            initialDelaySeconds: 5
+              port: {{ .Values.deployment.server.port }}
+            initialDelaySeconds: 20
             periodSeconds: 5
             failureThreshold: 5
             successThreshold: 1
@@ -65,5 +65,7 @@ spec:
                 name: git-ssh-key
                 key: id_rsa
           {{- end }}
+          - name: JAVA_OPTS
+            value: {{ .Values.deployment.java.opts }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}

--- a/_infra/helm/securebanking-spring-config-server/templates/service.yaml
+++ b/_infra/helm/securebanking-spring-config-server/templates/service.yaml
@@ -6,7 +6,7 @@ spec:
   type: ClusterIP
   ports:
   - port: 8080
-    targetPort: {{ .Values.server.port }}
+    targetPort: {{ .Values.deployment.server.port }}
     protocol: TCP
   selector:
     app: {{ .Chart.Name }}

--- a/_infra/helm/securebanking-spring-config-server/values.yaml
+++ b/_infra/helm/securebanking-spring-config-server/values.yaml
@@ -20,11 +20,11 @@ deployment:
 
   resources: 
     limits:
-      cpu: "500M"
-      memory: 512Mi
+      cpu: "500m"
+      memory: "512Mi"
     requests:
-      cpu: 500m
-      memory: 512Mi
+      cpu: "500m"
+      memory: "512Mi"
 
   server:
     port: 8888

--- a/_infra/helm/securebanking-spring-config-server/values.yaml
+++ b/_infra/helm/securebanking-spring-config-server/values.yaml
@@ -1,4 +1,5 @@
-deployment: 
+deployment:
+  apiVersion: apps/v1
   replicas: 1
 
   rollingUpdate:
@@ -7,17 +8,26 @@ deployment:
 
   imagePullPolicy: Always
 
-# Deploy a different image to the intended release (useful for test and development)
 
+  # Deploy a different image to the intended release (useful for test and development)
   imageOverride:
     enabled: true
     repo: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-spring-config-server
     tag: latest
 
-  resources: {}
-  
-server:
-  port: 8888
+  java:
+    opts: -XX:+UseG1GC -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -agentlib:jdwp=transport=dt_socket,address=*:9090,server=y,suspend=n
+
+  resources: 
+    limits:
+      cpu: "500M"
+      memory: 512Mi
+    requests:
+      cpu: 500m
+      memory: 512Mi
+
+  server:
+    port: 8888
 
 git:
   ssh: 


### PR DESCRIPTION
Huge amount of CPU being requested at start up caused node issue and
eviction of pods. We need to change the way tomcat is started such
that it respects the container memory limits and has a guaranteed
quality of service.

Set the following java opts;
-XX:+UseG1GC -XX:+UseContainerSupport -XX:MaxRAMPercentage=50

Update the chart version as extension/v1beta1 is old and I was getting
warnings that is deprecated, and it simply won't deploy on newer
versions of k8s, e.g. in local minikube.

Note: These changes dramatically increase the start up time of the
config server.This meant the pods were starting to fail as the liveness probe
wasn't responding in time. To address that I have increased the
intitalDelaySeconds value on the liveness probe

Issue: SecureBankingAccessToolkit/SecureBankingAccessToolkit#311